### PR TITLE
feat: add Binance USD-M private read-only client (testnet)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Binance USD-M Futures (TESTNET by default)
+BINANCE_USDM_BASE_URL=https://demo-fapi.binance.com
+
+# Put your demo-trading API keys in a local .env (NOT committed)
+BINANCE_USDM_API_KEY=
+BINANCE_USDM_API_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.env

--- a/adapters/binance_usdm_private.py
+++ b/adapters/binance_usdm_private.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+import requests
+
+
+@dataclass(frozen=True)
+class BinanceKeys:
+    api_key: str
+    api_secret: str
+
+
+class BinanceUsdmPrivateClient:
+    """
+    Minimal signed (USER_DATA) client for Binance USD-M Futures.
+    Designed for READ-ONLY checks first: account / balance / positions.
+
+    Testnet REST base URL (per docs): https://demo-fapi.binance.com
+    """
+
+    def __init__(
+        self,
+        keys: BinanceKeys,
+        base_url: str = "https://demo-fapi.binance.com",
+        timeout_sec: int = 10,
+        recv_window_ms: int = 5000,
+    ) -> None:
+        self.keys = keys
+        self.base_url = base_url.rstrip("/")
+        self.timeout_sec = timeout_sec
+        self.recv_window_ms = recv_window_ms
+
+    def _ts_ms(self) -> int:
+        return int(time.time() * 1000)
+
+    def _sign(self, params: Dict[str, Any]) -> str:
+        # Binance requires signature HMAC SHA256 over the query string.
+        # Signature should be appended at the end.
+        query = urlencode(params, doseq=True)
+        sig = hmac.new(
+            self.keys.api_secret.encode("utf-8"),
+            query.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return f"{query}&signature={sig}"
+
+    def _signed_get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        p: Dict[str, Any] = dict(params or {})
+        p["timestamp"] = self._ts_ms()
+        p.setdefault("recvWindow", self.recv_window_ms)
+
+        signed_qs = self._sign(p)
+        url = f"{self.base_url}{path}?{signed_qs}"
+
+        headers = {"X-MBX-APIKEY": self.keys.api_key}
+        resp = requests.get(url, headers=headers, timeout=self.timeout_sec)
+        resp.raise_for_status()
+        return resp.json()
+
+    # ---- READ-ONLY endpoints ----
+
+    def account_v2(self) -> Any:
+        # GET /fapi/v2/account
+        return self._signed_get("/fapi/v2/account")
+
+    def balance_v2(self) -> Any:
+        # GET /fapi/v2/balance
+        return self._signed_get("/fapi/v2/balance")
+
+    def position_risk_v2(self, symbol: Optional[str] = None) -> Any:
+        # GET /fapi/v2/positionRisk
+        params: Dict[str, Any] = {}
+        if symbol:
+            params["symbol"] = symbol
+        return self._signed_get("/fapi/v2/positionRisk", params=params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.31.0
+python-dotenv>=1.0.1

--- a/run/binance_private_check.py
+++ b/run/binance_private_check.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+from dotenv import load_dotenv
+load_dotenv()
+
+from adapters.binance_usdm_private import BinanceKeys, BinanceUsdmPrivateClient
+
+
+def _need(name: str) -> str:
+    v = os.getenv(name, "").strip()
+    if not v:
+        print(f"Missing env var: {name}")
+        return ""
+    return v
+
+
+def main() -> int:
+    base_url = os.getenv("BINANCE_USDM_BASE_URL", "https://demo-fapi.binance.com").strip()
+
+    api_key = _need("BINANCE_USDM_API_KEY")
+    api_secret = _need("BINANCE_USDM_API_SECRET")
+    if not api_key or not api_secret:
+        print("\nCreate a local .env (NOT committed) based on .env.example and put demo-trading keys there.")
+        return 2
+
+    c = BinanceUsdmPrivateClient(keys=BinanceKeys(api_key=api_key, api_secret=api_secret), base_url=base_url)
+
+    print("Account V2...")
+    acc = c.account_v2()
+    # Print only a few fields to keep output readable:
+    for k in ["totalWalletBalance", "availableBalance", "totalUnrealizedProfit", "totalMarginBalance"]:
+        if k in acc:
+            print(f"{k}: {acc[k]}")
+
+    print("\nPositionRisk V2 (BTCUSDT)...")
+    pr = c.position_risk_v2("BTCUSDT")
+    # API returns a list
+    if isinstance(pr, list) and pr:
+        p0 = pr[0]
+        for k in ["symbol", "positionAmt", "entryPrice", "unRealizedProfit", "leverage", "marginType"]:
+            if k in p0:
+                print(f"{k}: {p0[k]}")
+    else:
+        print("No positions returned (OK on a fresh demo account).")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,7 @@
+def test_imports():
+    from adapters.binance_usdm_public import BinanceUsdmPublicClient
+    from adapters.binance_usdm_private import BinanceUsdmPrivateClient, BinanceKeys
+
+    assert BinanceUsdmPublicClient
+    assert BinanceUsdmPrivateClient
+    assert BinanceKeys


### PR DESCRIPTION
what: signed read-only (account_v2, balance_v2, positionRisk_v2) on testnet

how to run: python -m run.binance_private_check

config: create local .env from .env.example (never committed)